### PR TITLE
Align navigation and footer layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,17 +16,17 @@
         <span class="logo-dot" aria-hidden="true"></span>
         <span>Flexam</span>
       </a>
-      <nav class="menu" aria-label="primary">
-        <a href="index.html">Software</a>
-        <a href="#" class="disabled" title="Coming soon">Applications</a>
-        <a href="about.html" aria-current="page">About Us</a>
-      </nav>
       <div class="cta">
         <a class="btn btn-primary" href="index.html#book">Book a Demo</a>
       </div>
       <button class="hamburger" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
         <i data-feather="menu"></i>
       </button>
+      <nav class="menu" aria-label="primary">
+        <a href="index.html">Software</a>
+        <a href="#" class="disabled" title="Coming soon">Applications</a>
+        <a href="about.html" aria-current="page">About Us</a>
+      </nav>
     </div>
     <nav id="mobile-menu" class="mobile-menu" hidden>
       <a href="index.html">Software</a>

--- a/index.html
+++ b/index.html
@@ -25,12 +25,6 @@
         <span>Flexam</span>
       </a>
 
-      <nav class="menu" aria-label="primary">
-        <a href="index.html" aria-current="page">Software</a>
-        <a href="#" class="disabled" title="Coming soon">Applications</a>
-        <a href="about.html">About Us</a>
-      </nav>
-
       <div class="cta">
         <a class="btn btn-primary" href="#book" data-cta="header">Book a Demo</a>
       </div>
@@ -38,6 +32,12 @@
       <button class="hamburger" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
         <i data-feather="menu"></i>
       </button>
+
+      <nav class="menu" aria-label="primary">
+        <a href="index.html" aria-current="page">Software</a>
+        <a href="#" class="disabled" title="Coming soon">Applications</a>
+        <a href="about.html">About Us</a>
+      </nav>
     </div>
 
     <nav id="mobile-menu" class="mobile-menu" hidden>

--- a/styles.css
+++ b/styles.css
@@ -61,7 +61,7 @@ img{ max-width:100%; display:block }
   border-bottom: 1px solid var(--line);
 }
 .nav{ display:flex; align-items:center; gap: var(--space); min-height:70px }
-.brand{ display:inline-flex; align-items:center; gap:10px; font-weight:800; color:inherit }
+.brand{ display:inline-flex; align-items:center; gap:10px; font-weight:800; color:inherit; margin-right:auto }
 .logo-dot{ width:16px; height:16px; border-radius:50%; background:var(--brand); display:inline-block }
 
 .menu{ display:none; gap: 22px }
@@ -154,8 +154,9 @@ img{ max-width:100%; display:block }
 
 /* === Footer === */
 .site-footer{ border-top:1px solid var(--line); background:#fff; padding: var(--space-lg) 0 }
-.footer-grid{ display:grid; gap: var(--space-lg) }
-.foot-links{ display:grid; grid-template-columns: repeat(2,minmax(120px,1fr)); gap:10px }
+.footer-grid{ display:flex; align-items:center; gap: var(--space-lg) }
+.foot-brand{ flex:0 0 auto }
+.foot-links{ flex:1; display:flex; justify-content:center; gap:20px }
 .foot-links a{ color:inherit }
 
 .foot-brand p{ margin:.3rem 0 }


### PR DESCRIPTION
## Summary
- Split header so Flexam logo stays on the left while navigation links sit on the right
- Center footer links with contact information anchored to the left

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c986d3938833197814c1214d67c00