### PR TITLE
Fix mobile navigation and footer layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -19,7 +19,7 @@
       <div class="cta">
         <a class="btn btn-primary" href="index.html#book">Book a Demo</a>
       </div>
-      <button class="hamburger" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
+      <button class="hamburger" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Toggle menu">
         <i data-feather="menu"></i>
       </button>
       <nav class="menu" aria-label="primary">

--- a/app.js
+++ b/app.js
@@ -6,10 +6,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const btn = document.querySelector('.hamburger');
   const menu = document.getElementById('mobile-menu');
   if (btn && menu) {
-    btn.addEventListener('click', () => {
+    const toggleMenu = () => {
       const isOpen = btn.getAttribute('aria-expanded') === 'true';
       btn.setAttribute('aria-expanded', String(!isOpen));
       menu.hidden = isOpen;
+    };
+    btn.addEventListener('click', toggleMenu);
+    // Close menu when a link is clicked
+    menu.addEventListener('click', (e) => {
+      if (e.target.tagName === 'A') {
+        btn.setAttribute('aria-expanded', 'false');
+        menu.hidden = true;
+      }
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <!-- Header -->
   <header class="site-header" data-blur>
     <div class="container nav">
-      <a class="brand" href="/">
+      <a class="brand" href="index.html">
         <span class="logo-dot" aria-hidden="true"></span>
         <span>Flexam</span>
       </a>
@@ -29,7 +29,7 @@
         <a class="btn btn-primary" href="#book" data-cta="header">Book a Demo</a>
       </div>
 
-      <button class="hamburger" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
+      <button class="hamburger" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Toggle menu">
         <i data-feather="menu"></i>
       </button>
 
@@ -220,7 +220,7 @@
   <footer class="site-footer">
     <div class="container footer-grid">
       <div class="foot-brand">
-        <a class="brand" href="/">
+        <a class="brand" href="index.html">
           <span class="logo-dot" aria-hidden="true"></span>
           <span>Flexam</span>
         </a>

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,7 @@ body{
 }
 
 a{ color:var(--brand); text-decoration:none }
+a:visited{ color:var(--brand) }
 a:hover{ text-decoration: underline }
 img{ max-width:100%; display:block }
 
@@ -72,7 +73,7 @@ img{ max-width:100%; display:block }
 .hamburger{ appearance:none; background:none; border:0; padding:6px 2px; cursor:pointer }
 .hamburger i{ width:28px; height:28px }
 
-.mobile-menu{ display:flex; flex-direction:column; gap:14px; padding: 10px var(--space) var(--space); border-top:1px solid var(--line); background:var(--bg) }
+.mobile-menu{ display:flex; flex-direction:column; gap:14px; padding: 10px var(--space) var(--space); border-top:1px solid var(--line); background:var(--bg); position:absolute; top:100%; left:0; right:0 }
 .mobile-menu .btn{ width:100% }
 
 @media (min-width: 980px){
@@ -160,6 +161,11 @@ img{ max-width:100%; display:block }
 .foot-links a{ color:inherit }
 
 .foot-brand p{ margin:.3rem 0 }
+
+@media (max-width: 700px){
+  .footer-grid{ flex-direction:column; align-items:flex-start; }
+  .foot-links{ flex-direction:column; align-items:flex-start; gap:10px; }
+}
 
 /* === About === */
 .hero-mini{ padding-top: clamp(30px, 5vw, 60px) }


### PR DESCRIPTION
## Summary
- ensure brand links use correct relative path and hamburger buttons are proper button elements
- improve mobile menu script to toggle/close correctly and keep visited links styled
- fix footer layout on narrow screens and position mobile menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c9f4668988331b8feb7779096bb8e