### PR TITLE
Tweak header, partners showcase and LinkedIn links

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,23 +16,23 @@
         <span class="logo-dot" aria-hidden="true"></span>
         <span>Flexam</span>
       </a>
-      <div class="cta">
-        <a class="btn btn-primary" href="index.html#book">Book a Demo</a>
-      </div>
-      <button class="hamburger" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Toggle menu">
-        <i data-feather="menu"></i>
-      </button>
       <nav class="menu" aria-label="primary">
         <a href="index.html">Software</a>
         <a href="#" class="disabled" title="Coming soon">Applications</a>
         <a href="about.html" aria-current="page">About Us</a>
       </nav>
+      <div class="cta">
+        <a class="btn btn-ghost" href="index.html#book">Book a Demo</a>
+      </div>
+      <button class="hamburger" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Toggle menu">
+        <i data-feather="menu"></i>
+      </button>
     </div>
     <nav id="mobile-menu" class="mobile-menu" hidden>
       <a href="index.html">Software</a>
       <a href="#" class="disabled">Applications</a>
       <a href="about.html" aria-current="page">About Us</a>
-      <a class="btn btn-primary" href="index.html#book">Book a Demo</a>
+      <a class="btn btn-ghost" href="index.html#book">Book a Demo</a>
     </nav>
   </header>
 
@@ -53,19 +53,19 @@
         <h2 class="h2">Founders</h2>
         <div class="cards">
           <article class="card founder">
-            <div class="avatar" aria-hidden="true">MI</div>
+            <div class="avatar" aria-hidden="true"></div>
             <h3>Mike Ivanov</h3>
             <p>Co‑founder & CTO, PhD in Robotics</p>
             <p class="muted">15+ years backend/cloud, 7 years robotics; safe & efficient multi‑axis systems.</p>
-            <p><a class="link" href="#" rel="noopener">LinkedIn</a></p>
+            <p><a class="link" href="#" rel="noopener" aria-label="LinkedIn"><i data-feather="linkedin"></i></a></p>
           </article>
 
           <article class="card founder">
-            <div class="avatar" aria-hidden="true">AG</div>
+            <div class="avatar" aria-hidden="true"></div>
             <h3>Artem Gordeev</h3>
             <p>Co‑founder & CEO, MBA in Entrepreneurship & Innovation</p>
             <p class="muted">Business, strategy, ops; customer discovery, go‑to‑market, partnerships.</p>
-            <p><a class="link" href="#" rel="noopener">LinkedIn</a></p>
+            <p><a class="link" href="#" rel="noopener" aria-label="LinkedIn"><i data-feather="linkedin"></i></a></p>
           </article>
         </div>
       </div>
@@ -96,6 +96,7 @@
         <a href="#" class="disabled">Applications</a>
         <a href="about.html">About Us</a>
         <a href="index.html#book">Book a Demo</a>
+        <a href="https://www.linkedin.com/company/flexamtech/" target="_blank" rel="noopener">LinkedIn</a>
         <a href="#" aria-disabled="true">Legal Notice</a>
         <a href="#" aria-disabled="true">Privacy Policy</a>
       </nav>

--- a/index.html
+++ b/index.html
@@ -25,26 +25,26 @@
         <span>Flexam</span>
       </a>
 
-      <div class="cta">
-        <a class="btn btn-primary" href="#book" data-cta="header">Book a Demo</a>
-      </div>
-
-      <button class="hamburger" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Toggle menu">
-        <i data-feather="menu"></i>
-      </button>
-
       <nav class="menu" aria-label="primary">
         <a href="index.html" aria-current="page">Software</a>
         <a href="#" class="disabled" title="Coming soon">Applications</a>
         <a href="about.html">About Us</a>
       </nav>
+
+      <div class="cta">
+        <a class="btn btn-ghost" href="#book" data-cta="header">Book a Demo</a>
+      </div>
+
+      <button class="hamburger" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Toggle menu">
+        <i data-feather="menu"></i>
+      </button>
     </div>
 
     <nav id="mobile-menu" class="mobile-menu" hidden>
       <a href="index.html" aria-current="page">Software</a>
       <a href="#" class="disabled">Applications</a>
       <a href="about.html">About Us</a>
-      <a class="btn btn-primary" href="#book">Book a Demo</a>
+      <a class="btn btn-ghost" href="#book">Book a Demo</a>
     </nav>
   </header>
 
@@ -53,10 +53,10 @@
     <section class="section hero">
       <div class="container grid-2">
         <div>
-          <h1 class="h1">
-            Automated slicing software.<br/>
-            Designed for robotic and multi‑axis 3D printing.
-          </h1>
+            <h1 class="h1 hero-title">
+              Automated slicing software.<br/>
+              Designed for robotic and multi‑axis 3D printing.
+            </h1>
           <p class="lead">
             Fully automated slicing tailored to your machines and workflows.
             Use the most advanced machine learning and slicing technology to stay ahead of the competition.
@@ -132,14 +132,12 @@
         <div class="split">
           <div>
             <h2 class="h2">Partners</h2>
-            <p>Logos of our technology and research partners will be featured here.</p>
+            <p>Trusted and supported by...</p>
           </div>
           <div class="logos">
-            <!-- Replace placeholders with real SVG/PNG; grayscale enforced via CSS -->
-            <div class="logo">FFG</div>
-            <div class="logo">FH Technikum Wien</div>
-            <div class="logo">AI for Good</div>
-            <div class="logo badge">More partners coming soon</div>
+            <div class="logo"><img src="logos/ffg.svg" alt="FFG"></div>
+            <div class="logo"><img src="logos/fh-technikum.svg" alt="FH Technikum Wien"></div>
+            <div class="logo"><img src="logos/ai-for-good.svg" alt="AI for Good"></div>
           </div>
         </div>
       </div>
@@ -233,6 +231,7 @@
         <a href="#" class="disabled">Applications</a>
         <a href="about.html">About Us</a>
         <a href="#book">Book a Demo</a>
+        <a href="https://www.linkedin.com/company/flexamtech/" target="_blank" rel="noopener">LinkedIn</a>
         <a href="#" aria-disabled="true">Legal Notice</a>
         <a href="#" aria-disabled="true">Privacy Policy</a>
       </nav>

--- a/logos/ai-for-good.svg
+++ b/logos/ai-for-good.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
+  <rect width="200" height="60" fill="white"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#555">AI for Good</text>
+</svg>

--- a/logos/ffg.svg
+++ b/logos/ffg.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
+  <rect width="200" height="60" fill="white"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="24" fill="#555">FFG</text>
+</svg>

--- a/logos/fh-technikum.svg
+++ b/logos/fh-technikum.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
+  <rect width="200" height="60" fill="white"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#555">FH Technikum</text>
+</svg>

--- a/styles.css
+++ b/styles.css
@@ -36,6 +36,7 @@ img{ max-width:100%; display:block }
 .container.narrow{ max-width: 860px }
 
 .h1{ font-weight:800; letter-spacing:-.02em; font-size:clamp(34px, 5.2vw, 58px); line-height:1.05; margin:0 0 var(--space) }
+.hero-title{ font-size:clamp(28px, 4.2vw, 50px); }
 .h2{ font-weight:800; letter-spacing:-.015em; font-size:clamp(26px, 3.6vw, 38px); margin:0 0 var(--space) }
 .lead{ font-size: clamp(18px, 2.2vw, 22px); color:var(--muted); margin:0 0 var(--space) }
 .text-xl{ font-size: clamp(18px, 2.2vw, 21px); color:var(--muted) }
@@ -134,11 +135,11 @@ img{ max-width:100%; display:block }
 /* === Partners === */
 .logos{ display:grid; grid-template-columns: repeat(auto-fit, minmax(160px,1fr)); gap:16px; align-items:center }
 .logo{
-  border:1px dashed var(--line);
-  border-radius: 10px; padding: 18px; text-align:center; color:#888; background:white;
+  border:1px solid var(--line);
+  border-radius: 10px; padding: 18px; text-align:center; background:white;
   filter: grayscale(100%); opacity:.9;
 }
-.logo.badge{ border-style: solid; font-weight:700; color:#666 }
+.logo img{ max-height:40px; margin:auto; display:block }
 
 /* === Steps === */
 .steps{ list-style:none; margin: var(--space-lg) 0 0; padding:0; display:grid; gap: 16px }
@@ -179,6 +180,7 @@ img{ max-width:100%; display:block }
   width:48px; height:48px; border-radius:12px; background:rgba(0,112,243,.08); color:var(--brand);
   display:grid; place-items:center; font-weight:800; margin-bottom:10px
 }
+.founders .link i{ width:20px; height:20px }
 
 /* === Utilities === */
 .actions{ display:flex; flex-wrap:wrap; gap:12px }


### PR DESCRIPTION
## Summary
- Move "Book a Demo" to the far right and tone down styling
- Reduce hero heading size and refresh partners section with logo placeholders
- Replace founder LinkedIn text links with icons and add LinkedIn link in footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a709861e208331981f549c28c91a66