### PR TITLE
Update contact details and LinkedIn profiles

### DIFF
--- a/about.html
+++ b/about.html
@@ -57,7 +57,7 @@
             <h3>Mike Ivanov</h3>
             <p>Co‑founder & CTO, PhD in Robotics</p>
             <p class="muted">15+ years backend/cloud, 7 years robotics; safe & efficient multi‑axis systems.</p>
-            <p><a class="link" href="#" rel="noopener" aria-label="LinkedIn"><i data-feather="linkedin"></i></a></p>
+            <p><a class="link" href="https://www.linkedin.com/in/l1va/" target="_blank" rel="noopener" aria-label="Mike Ivanov on LinkedIn"><i data-feather="linkedin"></i></a></p>
           </article>
 
           <article class="card founder">
@@ -65,7 +65,7 @@
             <h3>Artem Gordeev</h3>
             <p>Co‑founder & CEO, MBA in Entrepreneurship & Innovation</p>
             <p class="muted">Business, strategy, ops; customer discovery, go‑to‑market, partnerships.</p>
-            <p><a class="link" href="#" rel="noopener" aria-label="LinkedIn"><i data-feather="linkedin"></i></a></p>
+            <p><a class="link" href="https://www.linkedin.com/in/gordeevartem/" target="_blank" rel="noopener" aria-label="Artem Gordeev on LinkedIn"><i data-feather="linkedin"></i></a></p>
           </article>
         </div>
       </div>
@@ -74,7 +74,7 @@
     <section class="section">
       <div class="container narrow">
         <h2 class="h2">Contact</h2>
-        <p>📧 <a href="mailto:hello@flexam.pro">hello@flexam.pro</a></p>
+        <p>📧 <a href="mailto:hello@flexam.tech">hello@flexam.tech</a></p>
         <p>📍 Vienna, Austria</p>
       </div>
     </section>
@@ -88,7 +88,7 @@
           <span>Flexam</span>
         </a>
         <p>Flexam GmbH — Vienna, Austria</p>
-        <p>📧 <a href="mailto:hello@flexam.pro">hello@flexam.pro</a></p>
+        <p>📧 <a href="mailto:hello@flexam.tech">hello@flexam.tech</a></p>
         <p>© 2025 Flexam GmbH. All rights reserved. Made in Austria.</p>
       </div>
       <nav class="foot-links" aria-label="footer">

--- a/index.html
+++ b/index.html
@@ -198,8 +198,8 @@
           <h2 class="h2" id="book-title">Want your part sliced by Flexam?</h2>
           <p class="text-xl">Send us your 3D model and get ready‑to‑print G‑code.<br/>We’ll tailor the session to your machine, part types, and challenges.</p>
           <div class="actions">
-            <a class="btn btn-primary btn-lg" href="mailto:hello@flexam.pro?subject=Send%20a%20model%20for%20Flexam&body=Hi%20Flexam%2C%0A%0AHere%27s%20my%203D%20model%20for%20a%20test%20slice.%20Machine%20info%3A%20%5Brobot%2Fprinter%20type%5D%2C%20material%3A%20%5B...%5D%2C%20goals%3A%20%5B...%5D.%0A%0AThanks!" rel="noopener">👉 Send a model</a>
-            <a class="btn btn-ghost btn-lg" href="mailto:hello@flexam.pro?subject=Book%20a%20Demo%20with%20Flexam">Or book a demo</a>
+            <a class="btn btn-primary btn-lg" href="mailto:hello@flexam.tech?subject=Send%20a%20model%20for%20Flexam&body=Hi%20Flexam%2C%0A%0AHere%27s%20my%203D%20model%20for%20a%20test%20slice.%20Machine%20info%3A%20%5Brobot%2Fprinter%20type%5D%2C%20material%3A%20%5B...%5D%2C%20goals%3A%20%5B...%5D.%0A%0AThanks!" rel="noopener">👉 Send a model</a>
+            <a class="btn btn-ghost btn-lg" href="mailto:hello@flexam.tech?subject=Book%20a%20Demo%20with%20Flexam">Or book a demo</a>
           </div>
           <p class="fine">We’ll send G‑code and a short print report. NDA on request.</p>
         </div>
@@ -223,7 +223,7 @@
           <span>Flexam</span>
         </a>
         <p>Flexam GmbH — Vienna, Austria</p>
-        <p>📧 <a href="mailto:hello@flexam.pro">hello@flexam.pro</a></p>
+        <p>📧 <a href="mailto:hello@flexam.tech">hello@flexam.tech</a></p>
         <p>© 2025 Flexam GmbH. All rights reserved. Made in Austria.</p>
       </div>
       <nav class="foot-links" aria-label="footer">


### PR DESCRIPTION
## Summary
- switch all email links to use `hello@flexam.tech`
- link founders to personal LinkedIn profiles
- keep footer LinkedIn pointing to company page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a769389a108331ab4ef83c29c400d7