### PR TITLE
Remove FFG and FH references

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>About — Flexam</title>
-  <meta name="description" content="Reimagining how complex 3D printing gets done. Based in Vienna, backed by FFG." />
+  <meta name="description" content="Reimagining how complex 3D printing gets done. Based in Vienna." />
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
 </head>
@@ -42,9 +42,9 @@
         <h1 class="h1">Reimagining how complex 3D printing gets done.</h1>
         <p class="lead">
           Since 2021, we’re building slicing software for robotic and multi‑axis 3D printing.
-          Based in Vienna and backed by FFG, we work to bring industrial 3D printing into a more advanced era of manufacturing.
+          Based in Vienna, we work to bring industrial 3D printing into a more advanced era of manufacturing.
         </p>
-        <p class="microtrust">📍 Vienna, Austria • Backed by FFG</p>
+        <p class="microtrust">📍 Vienna, Austria</p>
       </div>
     </section>
 
@@ -53,7 +53,6 @@
         <h2 class="h2">Founders</h2>
         <div class="cards">
           <article class="card founder">
-            <div class="avatar" aria-hidden="true"></div>
             <h3>Mike Ivanov</h3>
             <p>Co‑founder & CTO, PhD in Robotics</p>
             <p class="muted">15+ years backend/cloud, 7 years robotics; safe & efficient multi‑axis systems.</p>
@@ -61,7 +60,6 @@
           </article>
 
           <article class="card founder">
-            <div class="avatar" aria-hidden="true"></div>
             <h3>Artem Gordeev</h3>
             <p>Co‑founder & CEO, MBA in Entrepreneurship & Innovation</p>
             <p class="muted">Business, strategy, ops; customer discovery, go‑to‑market, partnerships.</p>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
             <a class="btn btn-primary btn-lg" href="#book">👉 Book a Demo</a>
             <a class="btn btn-ghost btn-lg" href="#how">📄 See How It Works</a>
           </div>
-          <p class="microtrust">Backed by FFG • Vienna, Austria</p>
+          <p class="microtrust">Vienna, Austria</p>
         </div>
         <div class="hero-card">
           <div class="hero-stats">
@@ -135,8 +135,6 @@
             <p>Trusted and supported by...</p>
           </div>
           <div class="logos">
-            <div class="logo"><img src="logos/ffg.svg" alt="FFG"></div>
-            <div class="logo"><img src="logos/fh-technikum.svg" alt="FH Technikum Wien"></div>
             <div class="logo"><img src="logos/ai-for-good.svg" alt="AI for Good"></div>
           </div>
         </div>

--- a/logos/ffg.svg
+++ b/logos/ffg.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
-  <rect width="200" height="60" fill="white"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="24" fill="#555">FFG</text>
-</svg>

--- a/logos/fh-technikum.svg
+++ b/logos/fh-technikum.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
-  <rect width="200" height="60" fill="white"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#555">FH Technikum</text>
-</svg>

--- a/styles.css
+++ b/styles.css
@@ -176,10 +176,6 @@ img{ max-width:100%; display:block }
 .hero-mini{ padding-top: clamp(30px, 5vw, 60px) }
 .founders .cards{ display:grid; gap: var(--space); grid-template-columns: repeat(auto-fit,minmax(260px,1fr)) }
 .card{ background:#fff; border:1px solid var(--line); border-radius: var(--radius); padding: var(--space); box-shadow: var(--shadow) }
-.founder .avatar{
-  width:48px; height:48px; border-radius:12px; background:rgba(0,112,243,.08); color:var(--brand);
-  display:grid; place-items:center; font-weight:800; margin-bottom:10px
-}
 .founders .link i{ width:20px; height:20px }
 
 /* === Utilities === */


### PR DESCRIPTION
## Summary
- drop all FFG mentions from about and main pages
- remove partners entries for FFG and FH Technikum
- delete unused founder avatar placeholders and styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae07cd8d708331834052e4c31af678