### PR TITLE
Add AI for Good partner label and use JPG logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,10 @@
             <p>Trusted and supported by...</p>
           </div>
           <div class="logos">
-            <div class="logo"><img src="logos/ai-for-good.svg" alt="AI for Good"></div>
+            <div class="logo">
+              <img src="logos/ai-for-good.jpg" alt="AI for Good" />
+              <p class="logo-label">United Nations Boot Camp Finalist</p>
+            </div>
           </div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -141,6 +141,7 @@ img{ max-width:100%; display:block }
   filter: grayscale(100%); opacity:.9;
 }
 .logo img{ max-height:40px; margin:auto; display:block }
+.logo-label{ margin-top:8px; font-size:14px; color:#6b7280 }
 
 /* === Steps === */
 .steps{ list-style:none; margin: var(--space-lg) 0 0; padding:0; display:grid; gap: 16px }


### PR DESCRIPTION
## Summary
- Display "United Nations Boot Camp Finalist" label for AI for Good partnership
- Switch partners section to use JPG version of AI for Good logo
- Style partner labels for consistent appearance

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5e4cde23c8331b4741a993a2bd21d